### PR TITLE
Little tweaks

### DIFF
--- a/docs/drawer-dismissible.html
+++ b/docs/drawer-dismissible.html
@@ -44,7 +44,7 @@
     <div slot="app-content">
       <mega-top-app-bar>
         <mega-icon-button icon="menu" slot="navigationIcon"></mega-icon-button>
-        <div slot="title">Dismissable</div>
+        <div slot="title">Dismissible</div>
       </mega-top-app-bar>
       <div class="main-content">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,7 @@
     </mega-list-item>
     <mega-list-item href="./drawer.html">
       Drawer
-      <span slot="secondary">Dismissable side panels</span>
+      <span slot="secondary">Dismissible side panels</span>
       <span slot="meta">1.8 Kb</span>
       <img slot="icon" src="https://material-components-web.appspot.com/images/ic_side_navigation_24px.svg">
     </mega-list-item>

--- a/docs/snackbar.html
+++ b/docs/snackbar.html
@@ -21,7 +21,7 @@
   <mega-button onclick="leading()" unelevated>Leading</mega-button>
   <mega-button onclick="stacked()" unelevated>Stacked</mega-button>
 
-  <mega-snackbar id="el" dismissable>
+  <mega-snackbar id="el" dismissible>
     <span>Can't send photo. Retry in 5 seconds.</span>
     <mega-button slot="action">Retry</mega-button>
   </mega-snackbar>

--- a/docs/textfield.html
+++ b/docs/textfield.html
@@ -78,11 +78,11 @@
       <mega-textfield box disabled icon-trailing icon="event" label="Say something..." value="hi"></mega-textfield>
     </div>
 
-    <h4>fullWidth</h4>
-    <mega-textfield fullwidth></mega-textfield>
-    <mega-textfield fullwidth placeholder="Say something.."></mega-textfield>
-    <mega-textfield fullwidth label="Say something..."></mega-textfield>
-    <mega-textfield fullwidth label="Say something..." value="hi"></mega-textfield>
+    <h4>full-width</h4>
+    <mega-textfield full-width></mega-textfield>
+    <mega-textfield full-width placeholder="Say something.."></mega-textfield>
+    <mega-textfield full-width label="Say something..."></mega-textfield>
+    <mega-textfield full-width label="Say something..." value="hi"></mega-textfield>
 
     <h4>Notched Outline</h4>
     <p>The <code>&lt;mega-notched-outline&gt;</code> element provides the outline border and label handling</p>

--- a/src/snackbar.ts
+++ b/src/snackbar.ts
@@ -12,7 +12,7 @@ declare global {
 @customElement('mega-snackbar')
 export class SnackbarElement extends LitElement {
   @property({ type: Boolean, reflect: true })
-  dismissable = false;
+  dismissible = false;
 
   @property({ type: Boolean, reflect: true })
   opened = false;
@@ -237,7 +237,7 @@ mega-icon-button {
   --mega-icon-size: 18px;
   --mega-icon-button-padding: 9px;
 }
-:host(:not([dismissable])) mega-icon-button {
+:host(:not([dismissible])) mega-icon-button {
   display: none;
 }
 

--- a/src/textfield.ts
+++ b/src/textfield.ts
@@ -139,7 +139,7 @@ export class TextfieldElement extends LitElement {
         outline: none;
       }
 
-      :host([fullwidth]) {
+      :host([full-width]) {
         width: 100%;
       }
 


### PR DESCRIPTION
I came along these minor issues:

### dismissable vs dismissible

According to [dictionary.com](https://www.dictionary.com/browse/dismissible) it is the latter spelling.

Affected components:
- mega-snackbar
- mega-drawer

### fullwidth vs full-width

The attribute is `full-width` in the `@property` declaration of both `mega-button` and `mega-textfield`, but in the CSS (and demo) of the textfield, attribute was `fullwidth` instead. (which just didn't bind to anything.)

Affected components:
- mega-textfield